### PR TITLE
feat: Implement Orders and Coupons pages

### DIFF
--- a/src/app/(dashboard)/discounts/coupons/page.tsx
+++ b/src/app/(dashboard)/discounts/coupons/page.tsx
@@ -1,13 +1,59 @@
-import React from 'react'
+"use client";
+
+import React from "react";
+import useCoupons from "@/hooks/discounts/useCoupons";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import Loader from "@/components/shared/Loader";
 
 const Coupons = () => {
-  return (
-      <div className="container mx-auto py-10 px-4 sm:px-6 lg:px-8">
-         <h1 className="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">
-           All Coupons
-         </h1>
-       </div>
-  )
-}
+  const { coupons, loading, error } = useCoupons();
 
-export default Coupons
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <p className="text-red-500">{error}</p>;
+  }
+
+  return (
+    <div className="container mx-auto py-10 px-4 sm:px-6 lg:px-8">
+      <h1 className="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">
+        All Coupons
+      </h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Code</TableHead>
+            <TableHead>Discount Type</TableHead>
+            <TableHead>Value</TableHead>
+            <TableHead>Expiry Date</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {coupons.map((coupon) => (
+            <TableRow key={coupon.id}>
+              <TableCell>{coupon.code}</TableCell>
+              <TableCell>{coupon.discountType}</TableCell>
+              <TableCell>
+                {coupon.discountType === "percentage"
+                  ? `${coupon.value}%`
+                  : `$${coupon.value.toFixed(2)}`}
+              </TableCell>
+              <TableCell>{coupon.expiryDate}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default Coupons;

--- a/src/app/(dashboard)/sales/orders/page.tsx
+++ b/src/app/(dashboard)/sales/orders/page.tsx
@@ -1,11 +1,55 @@
+"use client";
+
 import React from "react";
+import useOrders from "@/hooks/sales/useOrders";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import Loader from "@/components/shared/Loader";
 
 const Orders = () => {
+  const { orders, loading, error } = useOrders();
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <p className="text-red-500">{error}</p>;
+  }
+
   return (
     <div className="container mx-auto py-10 px-4 sm:px-6 lg:px-8">
       <h1 className="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">
         All Orders
       </h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Order ID</TableHead>
+            <TableHead>Customer Name</TableHead>
+            <TableHead>Date</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map((order) => (
+            <TableRow key={order.id}>
+              <TableCell>{order.id}</TableCell>
+              <TableCell>{order.customerName}</TableCell>
+              <TableCell>{order.date}</TableCell>
+              <TableCell>{order.status}</TableCell>
+              <TableCell>${order.total.toFixed(2)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   );
 };

--- a/src/hooks/discounts/useCoupons.ts
+++ b/src/hooks/discounts/useCoupons.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import { Coupon } from "@/types/discounts/coupon";
+import { fetchAllCoupons } from "@/services/discounts/coupons.api";
+import { useAuth } from "@/providers/AuthProvider";
+
+const useCoupons = () => {
+  const { token } = useAuth();
+  const [coupons, setCoupons] = useState<Coupon[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const getCoupons = async () => {
+      try {
+        setLoading(true);
+        const fetchedCoupons = await fetchAllCoupons(token as string);
+        setCoupons(fetchedCoupons);
+      } catch (err) {
+        setError("Failed to fetch coupons.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (token) {
+      getCoupons();
+    }
+  }, [token]);
+
+  return { coupons, loading, error };
+};
+
+export default useCoupons;

--- a/src/hooks/sales/useOrders.ts
+++ b/src/hooks/sales/useOrders.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import { Order } from "@/types/sales/order";
+import { fetchAllOrders } from "@/services/sales/orders.api";
+import { useAuth } from "@/providers/AuthProvider";
+
+const useOrders = () => {
+  const { token } = useAuth();
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const getOrders = async () => {
+      try {
+        setLoading(true);
+        const fetchedOrders = await fetchAllOrders(token as string);
+        setOrders(fetchedOrders);
+      } catch (err) {
+        setError("Failed to fetch orders.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (token) {
+      getOrders();
+    }
+  }, [token]);
+
+  return { orders, loading, error };
+};
+
+export default useOrders;

--- a/src/services/discounts/coupons.api.ts
+++ b/src/services/discounts/coupons.api.ts
@@ -1,0 +1,19 @@
+import { Coupon } from "@/types/discounts/coupon";
+
+const mockCoupons: Coupon[] = [
+    { id: "1", code: "SUMMER20", discountType: "percentage", value: 20, expiryDate: "2024-08-31" },
+    { id: "2", code: "SAVE10", discountType: "fixed", value: 10, expiryDate: "2024-09-30" },
+    { id: "3", code: "FALLSALE", discountType: "percentage", value: 15, expiryDate: "2024-10-31" },
+];
+
+
+export const fetchAllCoupons = async (token?: string): Promise<Coupon[]> => {
+    console.log("Fetching coupons with token:", token);
+    // In a real application, you would make an API call here.
+    // For now, we're returning mock data.
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve(mockCoupons);
+        }, 500); // Simulate network delay
+    });
+};

--- a/src/services/sales/orders.api.ts
+++ b/src/services/sales/orders.api.ts
@@ -1,0 +1,18 @@
+import { Order } from "@/types/sales/order";
+
+const mockOrders: Order[] = [
+  { id: "1", customerName: "John Doe", date: "2023-01-15", status: "Delivered", total: 150.00 },
+  { id: "2", customerName: "Jane Smith", date: "2023-01-16", status: "Shipped", total: 75.50 },
+  { id: "3", customerName: "Alice Johnson", date: "2023-01-17", status: "Pending", total: 200.25 },
+];
+
+export const fetchAllOrders = async (token?: string): Promise<Order[]> => {
+  console.log("Fetching orders with token:", token);
+  // In a real application, you would make an API call here.
+  // For now, we're returning mock data.
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(mockOrders);
+    }, 500); // Simulate network delay
+  });
+};

--- a/src/types/discounts/coupon.ts
+++ b/src/types/discounts/coupon.ts
@@ -1,0 +1,7 @@
+export interface Coupon {
+  id: string;
+  code: string;
+  discountType: "percentage" | "fixed";
+  value: number;
+  expiryDate: string;
+}

--- a/src/types/sales/order.ts
+++ b/src/types/sales/order.ts
@@ -1,0 +1,7 @@
+export interface Order {
+  id: string;
+  customerName: string;
+  date: string;
+  status: "Pending" | "Shipped" | "Delivered" | "Cancelled";
+  total: number;
+}

--- a/src/utils/endpoints.ts
+++ b/src/utils/endpoints.ts
@@ -21,5 +21,11 @@ export const BakckendEndpoints = {
   ACCOUNT:{
     GET_ACCOUNT_DETAILS: `${API_BASE}/buyer/account/details/`,
     UPDATE_ACCOUNT_DETAILS: `${API_BASE}/buyer/account/update/`,
+  },
+  ORDERS: {
+    LIST_SELLER_ORDERS: `${API_BASE}/seller/orders/`,
+  },
+  COUPONS: {
+    LIST_SELLER_COUPONS: `${API_BASE}/seller/coupons/`,
   }
 };


### PR DESCRIPTION
This commit implements the "Orders" and "Coupons" pages, which were previously placeholders.

- Created mock API services to provide sample data for orders and coupons, simulating a backend connection.
- Added data types for `Order` and `Coupon`.
- Implemented custom hooks (`useOrders` and `useCoupons`) to handle state management for the new pages.
- Used existing UI components to build tables to display the data on the "Orders" and "Coupons" pages.
- Added loading and error handling states to provide a better user experience.